### PR TITLE
Install handler as a python package, allow better flexibility in application name, fix querystring handling, fix empty response bodies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ python:
   - '3.6'
 install:
   - yarn --ignore-engines install
-  - pip install -r requirements.txt
   - pip install -r requirements-test.txt
 script:
   - yarn run lint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Changelog
 
 
+## UNRELEASED
+
+### Changed
+- Handler is now installed as a python package instead of being copied into the
+   project source.
+- Querystring handling has been corrected.
+- Empty return body handling has been patched to match Now's requirement of a
+   `body` object on the response. An empty body is returned if no body is
+   supplied by the application.
+
+
 ## [1.0.4] - 2019-03-13 - Ensure logging configuration
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -56,12 +56,9 @@ from django_app.wsgi import application
 Look at your framework documentation for help getting access to the WSGI
 application.
 
-If the WSGI instance isn't named `application` you'll need adjust the import so
-the builder can find it when your project is being deployed. E.g.:
-
-```python
-from my_app.wsgi import app as application
-```
+If the WSGI instance isn't named `application` you can set the
+`wsgiApplicationName` configuration option to match your application's name (see
+the configuration section below).
 
 
 ### 3. Deploy!
@@ -100,6 +97,19 @@ Select the lambda runtime. Defaults to `python3.6`.
 {
     "builds": [{
         "config": { "runtime": "python3.6" }
+    }]
+}
+```
+
+
+### `wsgiApplicationName`
+
+Select the WSGI application to run from your entrypoint. Defaults to
+`application`.
+```json
+{
+    "builds": [{
+        "config": { "wsgiApplicationName": "application" }
     }]
 }
 ```

--- a/now_python_wsgi/__init__.py
+++ b/now_python_wsgi/__init__.py
@@ -1,1 +1,1 @@
-from .handler import handler # noqa
+from .handler import handler, now_handler # noqa

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,0 @@
-# Requirements for ./now_handler.py
-
-Werkzeug >=0.14,<1

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,23 @@
 #! /usr/bin/env python
+import json
+
 from setuptools import setup
+
+
+with open('package.json') as f:
+    package_data = json.loads(f.read())
+    version = package_data['version']
 
 
 """A barebones setup for tests
 """
 setup(
     name='now-python-wsgi',
+    version=version,
     packages=[
         'now_python_wsgi'
+    ],
+    install_requires=[
+        'Werkzeug==0.14.1',
     ]
 )


### PR DESCRIPTION
A string of fixes:
- Resolves #1 by always including `body` in the lambda return object, even if it's blank
- Resolves #2 by properly passing the path per the WSGI spec
- Avoids requirement conflicts by installing the handler as a python package
- Allows greater flexibility in the application name through the `wsgiApplicationName` config option